### PR TITLE
Fix dependency security advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,13 +10,12 @@
       "license": "MIT",
       "dependencies": {
         "@pinecone-database/pinecone": "^7.2.0",
-        "axios": "^1.15.0",
+        "axios": "^1.16.1",
         "commander": "^14.0.3",
         "cross-fetch": "^4.1.0",
         "dotenv": "^17.4.2",
         "express": "^5.2.1",
         "ffmpeg-static": "^5.3.0",
-        "follow-redirects": "^1.16.0",
         "openai": "^6.34.0",
         "pg": "^8.20.0",
         "punycode": "^2.3.1",
@@ -24,7 +23,7 @@
         "tiktoken": "^1.0.22",
         "ts-node": "^10.9.2",
         "typescript": "^6.0.2",
-        "yaml": "^2.8.3"
+        "yaml": "^2.9.0"
       },
       "devDependencies": {
         "@types/express": "^5.0.6",
@@ -1880,13 +1879,14 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
@@ -5001,9 +5001,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -6187,9 +6187,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/package.json
+++ b/package.json
@@ -15,13 +15,12 @@
   },
   "dependencies": {
     "@pinecone-database/pinecone": "^7.2.0",
-    "axios": "^1.15.0",
+    "axios": "^1.16.1",
     "commander": "^14.0.3",
     "cross-fetch": "^4.1.0",
     "dotenv": "^17.4.2",
     "express": "^5.2.1",
     "ffmpeg-static": "^5.3.0",
-    "follow-redirects": "^1.16.0",
     "openai": "^6.34.0",
     "pg": "^8.20.0",
     "punycode": "^2.3.1",
@@ -29,7 +28,7 @@
     "tiktoken": "^1.0.22",
     "ts-node": "^10.9.2",
     "typescript": "^6.0.2",
-    "yaml": "^2.8.3"
+    "yaml": "^2.9.0"
   },
   "devDependencies": {
     "@types/express": "^5.0.6",


### PR DESCRIPTION
## Summary
- raise axios to 1.16.1 to clear current axios advisories
- refresh qs and yaml through the lockfile
- remove the unused direct follow-redirects dependency while keeping it transitively through axios

## Verification
- npm ci
- npm audit
- npm test -- --runInBand