### PR TITLE
[codex] Update dependency drift

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,19 +14,19 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20]
+        node-version: ['26.3.0']
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
 
     - name: Set up Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ matrix.node-version }}
 
     - name: Install dependencies
-      run: npm install
+      run: npm ci
 
     - name: Run tests
       run: npm test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 # Use an official Node.js runtime as a parent image
-# Updated for Railway deployment - Node.js 20 LTS
-FROM node:20-slim AS production
+FROM node:26.3.0-bookworm-slim AS production
 
 # Set the working directory in the container to /app
 WORKDIR /app

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,12 +11,12 @@
       "dependencies": {
         "@pinecone-database/pinecone": "^7.2.0",
         "axios": "^1.16.1",
-        "commander": "^14.0.3",
+        "commander": "^15.0.0",
         "cross-fetch": "^4.1.0",
         "dotenv": "^17.4.2",
         "express": "^5.2.1",
         "ffmpeg-static": "^5.3.0",
-        "openai": "^6.39.1",
+        "openai": "^6.41.0",
         "pg": "^8.21.0",
         "punycode": "^2.3.1",
         "telegraf": "^4.16.3",
@@ -34,6 +34,9 @@
         "jest": "^30.4.2",
         "supertest": "^7.2.2",
         "ts-jest": "^29.4.11"
+      },
+      "engines": {
+        "node": "26.3.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2340,12 +2343,12 @@
       }
     },
     "node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/component-emitter": {
@@ -4547,13 +4550,10 @@
       }
     },
     "node_modules/openai": {
-      "version": "6.39.1",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.39.1.tgz",
-      "integrity": "sha512-z3dO9fEWOXBzlXynVb/xZ/tujzUjFWQWn3C0n0mw6Vo0zJTbEkaN4b2cLWjhJ6haJQx8LlREoafHRl+Gu/Hl+A==",
+      "version": "6.41.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.41.0.tgz",
+      "integrity": "sha512-IGWPopZq6Rjoynjfb3NSLf/z2MTw7UiOsm9TAjPGAjUESH7Uq41Trg4QWehBEn58p74i+m7uoRPV2vXcpPXhyA==",
       "license": "Apache-2.0",
-      "bin": {
-        "openai": "bin/cli"
-      },
       "peerDependencies": {
         "ws": "^8.18.0",
         "zod": "^3.25 || ^4.0"

--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "main": "index.js",
   "author": "Kirill Markin",
   "license": "MIT",
+  "packageManager": "npm@11.16.0",
+  "engines": {
+    "node": "26.3.0"
+  },
   "scripts": {
     "prestart": "node scripts/fetchConfig.js",
     "start": "ts-node --transpile-only src/bot.ts",
@@ -16,12 +20,12 @@
   "dependencies": {
     "@pinecone-database/pinecone": "^7.2.0",
     "axios": "^1.16.1",
-    "commander": "^14.0.3",
+    "commander": "^15.0.0",
     "cross-fetch": "^4.1.0",
     "dotenv": "^17.4.2",
     "express": "^5.2.1",
     "ffmpeg-static": "^5.3.0",
-    "openai": "^6.39.1",
+    "openai": "^6.41.0",
     "pg": "^8.21.0",
     "punycode": "^2.3.1",
     "telegraf": "^4.16.3",


### PR DESCRIPTION
## Summary
- align Node/npm runtime pins with latest stable Node 26.3.0 and npm 11.16.0
- update Docker and GitHub Actions runtime/tooling pins
- update commander to 15.0.0 and openai to 6.41.0

## Validation
- npm ci under Node 26.3.0/npm 11.16.0
- npm test -- --runInBand
- npm audit --json
- git diff --check
- structured compromised-package scan
- CLI help smoke with dummy env