### PR TITLE
[codex] Update dependency drift

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,11 +14,11 @@ jobs:
 
     strategy:
       matrix:
-        node-version: ['26.3.0']
+        node-version: ['26.3.1']
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: Set up Node.js
       uses: actions/setup-node@v6

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Node.js runtime as a parent image
-FROM node:26.3.0-bookworm-slim AS production
+FROM node:26.3.1-bookworm-slim AS production
 
 # Set the working directory in the container to /app
 WORKDIR /app

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,14 +10,14 @@
       "license": "MIT",
       "dependencies": {
         "@pinecone-database/pinecone": "^8.0.0",
-        "axios": "^1.18.0",
+        "axios": "^1.18.1",
         "commander": "^15.0.0",
         "cross-fetch": "^4.1.0",
         "dotenv": "^17.4.2",
         "express": "^5.2.1",
         "ffmpeg-static": "^5.3.0",
-        "openai": "^6.43.0",
-        "pg": "^8.21.0",
+        "openai": "^6.44.0",
+        "pg": "^8.22.0",
         "punycode": "^2.3.1",
         "telegraf": "^4.16.3",
         "tiktoken": "^1.0.22",
@@ -36,7 +36,7 @@
         "ts-jest": "^29.4.11"
       },
       "engines": {
-        "node": "26.3.0"
+        "node": "26.3.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1879,9 +1879,9 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
-      "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
@@ -4554,9 +4554,9 @@
       }
     },
     "node_modules/openai": {
-      "version": "6.43.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.43.0.tgz",
-      "integrity": "sha512-wVjioGjbnAZycj5mmkFVxbBxLEp+NkKpdMscCYP9LTbq+nbf1WTMVp+ovmD35jgyco4tldWZJkcqdmlh3O9yHQ==",
+      "version": "6.44.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.44.0.tgz",
+      "integrity": "sha512-09/gH+8jH0RgUwsgWHAaxsKGRT5zVZ95IaJUnqAWj6XejIBmnFRwq2WUIF37VtDEsmGrtPmvCs5+yBSeZGWvkA==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "ws": "^8.18.0",
@@ -4720,14 +4720,14 @@
       }
     },
     "node_modules/pg": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.21.0.tgz",
-      "integrity": "sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA==",
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.22.0.tgz",
+      "integrity": "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==",
       "license": "MIT",
       "dependencies": {
-        "pg-connection-string": "^2.13.0",
+        "pg-connection-string": "^2.14.0",
         "pg-pool": "^3.14.0",
-        "pg-protocol": "^1.14.0",
+        "pg-protocol": "^1.15.0",
         "pg-types": "2.2.0",
         "pgpass": "1.0.5"
       },
@@ -4754,9 +4754,9 @@
       "optional": true
     },
     "node_modules/pg-connection-string": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.13.0.tgz",
-      "integrity": "sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.14.0.tgz",
+      "integrity": "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==",
       "license": "MIT"
     },
     "node_modules/pg-int8": {
@@ -4777,9 +4777,9 @@
       }
     },
     "node_modules/pg-protocol": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.14.0.tgz",
-      "integrity": "sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.15.0.tgz",
+      "integrity": "sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==",
       "license": "MIT"
     },
     "node_modules/pg-types": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "packageManager": "npm@11.17.0",
   "engines": {
-    "node": "26.3.0"
+    "node": "26.3.1"
   },
   "scripts": {
     "prestart": "node scripts/fetchConfig.js",
@@ -19,14 +19,14 @@
   },
   "dependencies": {
     "@pinecone-database/pinecone": "^8.0.0",
-    "axios": "^1.18.0",
+    "axios": "^1.18.1",
     "commander": "^15.0.0",
     "cross-fetch": "^4.1.0",
     "dotenv": "^17.4.2",
     "express": "^5.2.1",
     "ffmpeg-static": "^5.3.0",
-    "openai": "^6.43.0",
-    "pg": "^8.21.0",
+    "openai": "^6.44.0",
+    "pg": "^8.22.0",
     "punycode": "^2.3.1",
     "telegraf": "^4.16.3",
     "tiktoken": "^1.0.22",

--- a/src/messageHandlers.ts
+++ b/src/messageHandlers.ts
@@ -1,5 +1,6 @@
 import fs from "fs";
 import axios from "axios";
+import { randomUUID } from "crypto";
 import { MyContext, MyMessage, UserData, NoOpenAiApiKeyError } from "./types";
 import { ERROR_MESSAGE, MAX_TRIAL_TOKENS, NO_VIDEO_ERROR } from './config';
 import { 
@@ -364,8 +365,7 @@ export async function handlePhotoMessage(ctx: MyContext): Promise<string> {
     const fileId = photo.file_id;
     
     // Generate unique file paths
-    const timestamp = Date.now();
-    const uniqueId = `${fileId}-${timestamp}`;
+    const uniqueId = `${fileId}-${randomUUID()}`;
     const inputFilePath = `./temp/${uniqueId}.jpg`;
     const resizedFilePath = `./temp/${uniqueId}_resized.jpg`;
 


### PR DESCRIPTION
## Summary
- Update Node runtime pins, Docker base, checkout action, and direct npm dependencies to current stable targets.
- Refresh package-lock transitive pg packages.
- Replace millisecond-based photo temp file suffixes with random UUIDs after validation exposed collisions.

## Validation
- npm ci
- npm test -- --runInBand
- npm outdated --json --include=dev --long
- npm audit --omit=dev --json
- npm audit signatures
- supply-chain indicator scans
- YAML/JSON parse checks
- git diff --check