### PR TITLE
Align dependency and runtime versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: ['26.3.1']
+        node-version: ['26.4.0']
 
     steps:
     - name: Checkout code

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Node.js runtime as a parent image
-FROM node:26.3.1-bookworm-slim AS production
+FROM node:26.4.0-bookworm-slim AS production
 
 # Set the working directory in the container to /app
 WORKDIR /app

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "dotenv": "^17.4.2",
         "express": "^5.2.1",
         "ffmpeg-static": "^5.3.0",
-        "openai": "^6.44.0",
+        "openai": "^6.45.0",
         "pg": "^8.22.0",
         "punycode": "^2.3.1",
         "telegraf": "^4.16.3",
@@ -36,7 +36,7 @@
         "ts-jest": "^29.4.11"
       },
       "engines": {
-        "node": "26.3.1"
+        "node": "26.4.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -4150,9 +4150,9 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4554,15 +4554,27 @@
       }
     },
     "node_modules/openai": {
-      "version": "6.44.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.44.0.tgz",
-      "integrity": "sha512-09/gH+8jH0RgUwsgWHAaxsKGRT5zVZ95IaJUnqAWj6XejIBmnFRwq2WUIF37VtDEsmGrtPmvCs5+yBSeZGWvkA==",
+      "version": "6.45.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.45.0.tgz",
+      "integrity": "sha512-5DQVNErssk0afNpTTHUm/qZPU4iKR9OYdNid8Ib4puq4gHNNvGWZht2zY4h9a8JMF949Ik6m8gQutllVPbjdnw==",
       "license": "Apache-2.0",
       "peerDependencies": {
+        "@aws-sdk/credential-provider-node": ">=3.972.0 <4",
+        "@smithy/hash-node": ">=4.3.0 <5",
+        "@smithy/signature-v4": ">=5.4.0 <6",
         "ws": "^8.18.0",
         "zod": "^3.25 || ^4.0"
       },
       "peerDependenciesMeta": {
+        "@aws-sdk/credential-provider-node": {
+          "optional": true
+        },
+        "@smithy/hash-node": {
+          "optional": true
+        },
+        "@smithy/signature-v4": {
+          "optional": true
+        },
         "ws": {
           "optional": true
         },

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "main": "index.js",
   "author": "Kirill Markin",
   "license": "MIT",
-  "packageManager": "npm@11.17.0",
+  "packageManager": "npm@11.18.0",
   "engines": {
-    "node": "26.3.1"
+    "node": "26.4.0"
   },
   "scripts": {
     "prestart": "node scripts/fetchConfig.js",
@@ -25,7 +25,7 @@
     "dotenv": "^17.4.2",
     "express": "^5.2.1",
     "ffmpeg-static": "^5.3.0",
-    "openai": "^6.44.0",
+    "openai": "^6.45.0",
     "pg": "^8.22.0",
     "punycode": "^2.3.1",
     "telegraf": "^4.16.3",
@@ -45,9 +45,11 @@
     "ts-jest": "^29.4.11"
   },
   "overrides": {
-    "glob": "^13.0.6"
+    "glob": "^13.0.6",
+    "js-yaml": "^3.15.0"
   },
   "resolutions": {
-    "glob": "^13.0.6"
+    "glob": "^13.0.6",
+    "js-yaml": "^3.15.0"
   }
 }


### PR DESCRIPTION
## Summary
- align Node runtime references from 26.3.1 to 26.4.0
- align npm packageManager from 11.17.0 to 11.18.0
- update OpenAI SDK from ^6.44.0 to ^6.45.0
- override transitive dev js-yaml from 3.14.2 to 3.15.0 for audit coverage

## Validation
- npm ci with Node 26.4.0 and npm 11.18.0
- npm test -- --runInBand
- npm outdated --json --include=dev --long
- npm audit --json
- npm audit --omit=dev --json
- npm audit signatures
- Docker manifest inspect node:26.4.0-bookworm-slim
- JSON/YAML config parse checks
- git diff --check

## Supply-chain check
- scanned current dependency/action names for recently compromised package indicators; no matches found