### PR TITLE
chore: align dependency and runtime versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,19 +14,19 @@ jobs:
 
     strategy:
       matrix:
-        node-version: ['26.4.0']
+        node-version: ['26.5.0']
 
     steps:
     - name: Checkout code
       uses: actions/checkout@v7
 
     - name: Set up Node.js
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@v7
       with:
         node-version: ${{ matrix.node-version }}
 
     - name: Install dependencies
-      run: npm ci
+      run: npx --yes npm@12.0.1 ci
 
     - name: Run tests
       run: npm test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Node.js runtime as a parent image
-FROM node:26.4.0-bookworm-slim AS production
+FROM node:26.5.0-bookworm-slim AS production
 
 # Set the working directory in the container to /app
 WORKDIR /app
@@ -7,8 +7,8 @@ WORKDIR /app
 # Copy package files first to leverage Docker cache
 COPY package*.json ./
 
-# Install app dependencies
-RUN npm ci
+# Install app dependencies with the pinned package manager
+RUN npx --yes npm@12.0.1 ci
 
 # Copy the rest of the application
 COPY . .

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "dotenv": "^17.4.2",
         "express": "^5.2.1",
         "ffmpeg-static": "^5.3.0",
-        "openai": "^6.45.0",
+        "openai": "^6.47.0",
         "pg": "^8.22.0",
         "punycode": "^2.3.1",
         "telegraf": "^4.16.3",
@@ -30,13 +30,14 @@
         "@types/fluent-ffmpeg": "^2.1.28",
         "@types/jest": "^30.0.0",
         "@types/pg": "^8.20.0",
-        "@types/supertest": "^7.2.0",
+        "@types/supertest": "^7.2.1",
         "jest": "^30.4.2",
         "supertest": "^7.2.2",
         "ts-jest": "^29.4.11"
       },
       "engines": {
-        "node": "26.4.0"
+        "node": "26.5.0",
+        "npm": "12.0.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1371,9 +1372,9 @@
       }
     },
     "node_modules/@types/supertest": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-7.2.0.tgz",
-      "integrity": "sha512-uh2Lv57xvggst6lCqNdFAmDSvoMG7M/HDtX4iUCquxQ5EGPtaPM5PL5Hmi7LCvOG8db7YaCPNJEeoI8s/WzIQw==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-7.2.1.tgz",
+      "integrity": "sha512-4CbBvoYVLHL7+yhbYrZET0vsvuyXTC05aRe7dNQkwMzm56auceoy6Yu3K50uZmwfHna1os3CMSgM/3QVkUtPTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4554,9 +4555,9 @@
       }
     },
     "node_modules/openai": {
-      "version": "6.45.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.45.0.tgz",
-      "integrity": "sha512-5DQVNErssk0afNpTTHUm/qZPU4iKR9OYdNid8Ib4puq4gHNNvGWZht2zY4h9a8JMF949Ik6m8gQutllVPbjdnw==",
+      "version": "6.47.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.47.0.tgz",
+      "integrity": "sha512-xYr+R9woSzWxVxeiqkkNbHhv89tZDEI6eBMbrdPnv3poh+mijHvbhS35a+3o6xHa411/ns8j5ENY3So9DCXWYw==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@aws-sdk/credential-provider-node": ">=3.972.0 <4",

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "main": "index.js",
   "author": "Kirill Markin",
   "license": "MIT",
-  "packageManager": "npm@11.18.0",
+  "packageManager": "npm@12.0.1",
   "engines": {
-    "node": "26.4.0"
+    "node": "26.5.0",
+    "npm": "12.0.1"
   },
   "scripts": {
     "prestart": "node scripts/fetchConfig.js",
@@ -17,6 +18,11 @@
     "remove-premium": "ts-node src/cli.ts remove-premium",
     "list-premium": "ts-node src/cli.ts list-premium"
   },
+  "allowScripts": {
+    "ffmpeg-static@5.3.0": true,
+    "fsevents": false,
+    "unrs-resolver@1.12.2": true
+  },
   "dependencies": {
     "@pinecone-database/pinecone": "^8.0.0",
     "axios": "^1.18.1",
@@ -25,7 +31,7 @@
     "dotenv": "^17.4.2",
     "express": "^5.2.1",
     "ffmpeg-static": "^5.3.0",
-    "openai": "^6.45.0",
+    "openai": "^6.47.0",
     "pg": "^8.22.0",
     "punycode": "^2.3.1",
     "telegraf": "^4.16.3",
@@ -39,7 +45,7 @@
     "@types/fluent-ffmpeg": "^2.1.28",
     "@types/jest": "^30.0.0",
     "@types/pg": "^8.20.0",
-    "@types/supertest": "^7.2.0",
+    "@types/supertest": "^7.2.1",
     "jest": "^30.4.2",
     "supertest": "^7.2.2",
     "ts-jest": "^29.4.11"


### PR DESCRIPTION
## Summary
- update Node.js, npm, Docker, and GitHub Actions toolchain pins
- update OpenAI SDK and Supertest type definitions
- configure npm 12 install-script approvals for required dependencies

## Validation
- npm ci with Node.js 26.5.0 and npm 12.0.1
- 4 Jest suites and 30 tests passed
- TypeScript no-emit check passed
- npm audit reports 0 vulnerabilities
- GitHub malware advisory scan found 0 matches across 466 resolved versions
- ffmpeg-static binary smoke test passed

Docker image build was not run because the local Docker daemon was unavailable; the node:26.5.0-bookworm-slim tag was verified to exist.